### PR TITLE
🐛[FIX] JWT 설정 바인딩 실패로 서버 부팅 NPE 발생 (sejin.jwt prefix/secret 로딩 문제)

### DIFF
--- a/src/main/java/com/sejin/platform/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/sejin/platform/common/security/JwtTokenProvider.java
@@ -31,6 +31,13 @@ public class JwtTokenProvider {
 
     public JwtTokenProvider(JwtProperties jwtProperties) {
         this.jwtProperties = jwtProperties;
+        
+        // 설정 누락을 빠르게 확인하기 위한 코드 추가
+        if(jwtProperties.getSecret() == null || jwtProperties.getSecret().isBlank()) {
+        	throw new IllegalStateException(
+        			"JWT secret이 비었음. sejin.jwt.secret 설정 확인 바람"
+			);
+        }
 
         // 시크릿 문자열을 기반으로 서명 키를 생성
         // 키 길이가 너무 짧으면 예외가 날 수 있어서 운영에서는 충분히 길게 잡아야 함

--- a/src/main/resources/application-secrets.properties
+++ b/src/main/resources/application-secrets.properties
@@ -2,10 +2,10 @@
 # JWT secret, 외부 API 키, 암호화 키 등...
 
 # JWT 서명 키
-jwt.secret=1/mySqZYFOugJdz30jR7A5SQ3l7BudnvjNumfSQ5eRLTQwovDcPCb9JEEUims7RQT5cEola+oMFKVzov6G1pxA==
+sejin.jwt.secret=1/mySqZYFOugJdz30jR7A5SQ3l7BudnvjNumfSQ5eRLTQwovDcPCb9JEEUims7RQT5cEola+oMFKVzov6G1pxA==
 
 # JWT 토큰 만료시간 설정
 # 1시간
-jwt.access-token-validity=3600000
+sejin.jwt.access-token-expire-ms=3600000
 # 일주일
-jwt.refresh-token-validity=604800000
+sejin.jwt.refresh-token-expire-ms=604800000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,12 @@
 ## 프로젝트가 시작될 때 가장 먼저 읽는 메인 설정 파일
-## 나머지 설정 파일(cmmon/db/secrets)을 추가로 읽으라고 연결해주는 역할
+## spring.config.import로 다른 properties를 추라고 합쳐서 읽게 만드는 연결 역할
+## 나머지 설정 파일(common/db/secrets)을 추가로 읽으라고 연결해주는 역할
 
 spring.application.name=sejin
 
-spring.config.import=optional:classpath:application-common.properties,optional:classpath:application-db.properties,optional:classpath:application-secrets.properties
+
+#spring.config.import=optional:classpath:application-common.properties,optional:classpath:application-db.properties,optional:classpath:application-secrets.properties
+
+# 개발 단계에서는 secrets만 optional을 빼서 서버 시작 시 못 읽으면 바로 터지게 함
+# application-secrets.properties가 없거나 경로가 틀리면 시작 단계에서 바로 에러가 나서 디버깅이 쉬워짐
+spring.config.import=optional:classpath:application-common.properties,optional:classpath:application-db.properties,classpath:application-secrets.properties


### PR DESCRIPTION
## 🧾 PR 한줄 요약
설명: sejin.jwt 설정 키를 정상 바인딩되게 정리하고, secrets 파일 로딩을 개발 단계에서 필수로 강제해서 JWT secret 누락으로 서버가 죽는 문제를 해결

---

## 🧩 배경/문제 (Why)
설명: 서버 실행 시 JWT 설정(secret)이 주입되지 않아서 JwtTokenProvider 생성자에서 NPE가 터지고, Spring Boot가 부팅 단계에서 바로 종료되는 문제 발생.

상세 : 
1. JwtProperties는 @ConfigurationProperties(prefix = "sejin.jwt")로 설정을 읽는데, secrets 파일의 키(prefix/이름)가 달라서 값이 바인딩되지 않았음

2. spring.config.import에서 secrets가 optional이라 파일이 누락/경로 오류여도 조용히 넘어가서 원인 파악이 더 어려웠음

관련 이슈: #8 

## 🎯 목표/범위 (Scope)
[IN]
1. JWT 설정 키를 sejin.jwt.*로 통일해서 JwtProperties에 정상 바인딩되게 수정

2. 개발 단계에서 application-secrets.properties 로딩을 필수로 강제(누락 시 즉시 실패)

3. JwtTokenProvider에서 secret 누락 시 NPE 대신 명확한 예외로 fail-fast 처리

[OUT]
1. JWT 발급/검증 로직 구조 변경(메서드/클레임 설계 등)은 범위 제외

2. 운영 환경에서 secrets 주입 방식(환경변수/Secret Manager 전환)은 이번 PR 범위 제외

## 🛠️ 변경 내용 (What)
src/main/resources/application-secrets.properties

sejin.jwt.secret, sejin.jwt.access-token-expire-ms, sejin.jwt.refresh-token-expire-ms로 키 통일

src/main/resources/application.properties

spring.config.import에서 secrets만 optional 제거해서 dev에서 누락/경로 오류 시 바로 실패하도록 변경

src/main/java/com/sejin/platform/common/security/JwtTokenProvider.java

jwtProperties.getSecret() 누락 시 IllegalStateException을 던지도록 방어 코드 추가(키 생성 전에 체크)

## 🧠 설계/의사결정 (How & Decision)
선택한 방식: 설정 키(prefix)를 JwtProperties(prefix="sejin.jwt")에 맞춰서 application-secrets.properties의 키를 통일함

고려한 대안: JwtProperties의 prefix를 jwt로 바꾸는 방법도 있었지만, 프로젝트 설정 네임스페이스를 sejin.jwt로 유지하는 게 더 일관적이라 현재 구조를 유지함

추가 결정: 개발 단계에서 secrets import를 optional로 두면 “파일을 못 읽어도 조용히 넘어가는” 문제가 생겨서, secrets만 필수 로딩으로 바꿔서 디버깅 난이도를 낮춤

주의점: fail-fast 예외를 추가해 NPE 대신 “어떤 설정이 빠졌는지” 바로 보이게 해서 재발 시 원인 파악 시간을 줄이도록 함


## ✅ 테스트/검증 (Verification)
테스트 시나리오

application-secrets.properties 정상 존재 상태로 서버 실행 → 부팅 정상 확인

sejin.jwt.secret 값을 일부러 비우고 실행 → IllegalStateException 메시지로 즉시 실패하는지 확인

spring.config.import에서 secrets 파일 경로를 일부러 틀리게 변경 후 실행 → 시작 단계에서 import 에러로 바로 실패하는지 확인

체크리스트

 로컬 실행 정상

 secrets 누락/빈 값 케이스에서 에러 메시지 명확히 확인

 secrets 파일 미로딩(경로 오류) 시 즉시 실패 확인


## 🔜 TODO / Follow-up

  - [ ] 운영 환경에서는 application-secrets.properties 대신 환경변수/Secret Manager 기반 주입 방식으로 전환 검토
