### PR TITLE
🐛fix: DB 연결 설정을 로컬에서 AWS RDS로 변경

### DIFF
--- a/src/main/resources/application-db.properties
+++ b/src/main/resources/application-db.properties
@@ -2,14 +2,18 @@
 # 나중에 DB 서버/계정이 바뀌어도 여기만 수정하면 되게 분리해두는 목적
 
 # DB 연결 정보
-spring.datasource.url=jdbc:mysql://localhost:3306/sejin?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
-spring.datasource.username=sejin_app
-spring.datasource.password=8561
+spring.datasource.url=jdbc:mysql://sejin-mysql.c7mosyia8pfq.ap-southeast-2.rds.amazonaws.com:3306/sejin?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource.username=nocount
+spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # JPA
 # DB 스키마를 직접 관리하고 검증만 하는 용도
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.generate-ddl=false
+
+
+
+
 
 


### PR DESCRIPTION
## 🧾 PR 한줄 요약
설명: DB 접속 정보를 로컬 MySQL(localhost)에서 AWS RDS 엔드포인트로 변경해서, 어느 환경에서도 같은 DB를 바라보게 수정

---

## 🧩 배경/문제 (Why)
설명: 초기에 PC 로컬 DB로 개발하다가 DB를 AWS RDS로 올렸는데, 설정 파일이 로컬 기준으로 남아있어서 외부(노트북/다른 환경)에서 실행하면 DB 연결이 안 되는 문제 발생.

기존 설정 :
- spring.datasource.url이 jdbc:mysql://localhost:3306/...로 되어 있어서 내 PC가 아닌 환경에서는 접속 불가

- 계정도 로컬 기준(sejin_app)이라 RDS 계정과 불일치 가능
  - 관련 이슈: #10 

---

## 🎯 목표/범위 (Scope)
[IN]
1. application-db.properties의 datasource URL을 AWS RDS로 변경
2. datasource username을 RDS 계정으로 변경

---

## 🛠️ 변경 내용 (What)
src/main/resources/application-db.properties

- spring.datasource.url
      localhost:3306 → sejin-mysql.c7mosyia8pfq.ap-southeast-2.rds.amazonaws.com:3306

- spring.datasource.username
      sejin_app → nocount

- JPA 스키마 정책은 기존 유지
spring.jpa.hibernate.ddl-auto=validate
spring.jpa.generate-ddl=false

---

## 🧠 설계/의사결정 (How & Decision)
선택한 방식: DB 접속 설정을 application-db.properties에 유지하면서, URL/계정만 RDS로 바꿈

이유: DB 서버/계정이 바뀔 때 영향 범위를 최소화하려고 DB 관련 설정은 한 파일에서 관리하는 구조를 유지함

주의점: 운영에서는 비밀번호를 파일에 직접 적기보다는 환경변수/시크릿 매니저로 주입하는 방식으로 정리할 예정

---

## ✅ 테스트/검증 (Verification)
테스트 시나리오
- 서버 실행 → DB 연결 성공 확인

체크리스트
- 로컬 실행 정상
- RDS 연결 성공
- ddl-auto=validate 유지 상태에서 스키마 검증 오류 없
---

## 🔜 TODO / Follow-up
  - [ ] DB 비밀번호는 application-secrets.properties 또는 환경변수로 이동해서 관리 방식 통일
