### PR TITLE
📦[CHORE] MyBatis DB 테스트 세팅 및 개발용 Security 설정 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,13 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	
+	// mybatis
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	
+	
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sejin/platform/config/mybatis/MyBatisConfig.java
+++ b/src/main/java/com/sejin/platform/config/mybatis/MyBatisConfig.java
@@ -1,0 +1,47 @@
+package com.sejin.platform.config.mybatis;
+
+import javax.sql.DataSource;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.annotation.MapperScan;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+@Configuration
+@MapperScan("com.sejin.platform") // 매퍼 패키지 스캔 범위
+public class MyBatisConfig {
+
+	@Bean
+	public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+
+		// MyBatis가 쓸 SqlSessionFactory를 직접 생성
+		SqlSessionFactoryBean factoryBean = new SqlSessionFactoryBean();
+
+		// 스프링이 만든 DataSource를 Mybatis에 연결
+		// DataSource는 DB url, 아이디, 비번 같은 설정으로 이미 만들어져 있는 객체
+		factoryBean.setDataSource(dataSource);
+
+		// XML 매퍼 파일을 읽을 위치 지정
+		Resource[] mapperXmlFiles = new PathMatchingResourcePatternResolver()
+				.getResources("classpath:/mapper/**/*.xml");
+		factoryBean.setMapperLocations(mapperXmlFiles);
+
+		// DB 컬럼이 스네이크 표기법이어도 카멜케이스로 자동 매핑되게 함
+		org.apache.ibatis.session.Configuration mybatisSetting = new org.apache.ibatis.session.Configuration();
+		mybatisSetting.setMapUnderscoreToCamelCase(true);
+		factoryBean.setConfiguration(mybatisSetting);
+
+		// SqlSessionFactory를 최종 생성해서 스프링 빈으로 등록
+		return factoryBean.getObject();
+	}
+
+	@Bean
+	public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
+		return new SqlSessionTemplate(sqlSessionFactory);
+	}
+}

--- a/src/main/java/com/sejin/platform/config/security/SecurityConfig.java
+++ b/src/main/java/com/sejin/platform/config/security/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.sejin.platform.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+	
+	// 개발 단계에서는 로그인 화면 때문에 테스트가 계속 막힘
+	// 현 단계에서는 모든 요청을 허용해서 개발을 편하게 진행한다.
+	// 나중에 기능 개발이 끝나면 정책을 바꿔서 인증과 권한을 적용한다.
+	
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+		
+		// 개발 단계에서는 POST 요청 테스트를 많이 하기 때문에 CSRF 때문에 403이 뜨는 상황을 막기 위해 꺼둠
+		http.csrf(csrf -> csrf.disable());
+		
+		//로그인 기능을 만들기 전이라 기본 로그인 폼이 뜨는 것도 꺼둠.
+		http.formLogin(form -> form.disable());
+		
+		// 브라우저 기본 로그인 팝업도 필요 없으니 꺼둠.
+		http.httpBasic(basic -> basic.disable());
+		
+		// 개발 단계에서는 모든 URL 요청을 허용
+		http.authorizeHttpRequests(auth -> auth
+					.anyRequest().permitAll()
+				);
+		
+		// 스프링 시큐리티에 등록
+		return http.build();
+	}
+	
+}

--- a/src/main/resources/application-common.properties
+++ b/src/main/resources/application-common.properties
@@ -29,3 +29,10 @@ spring.jpa.properties.hibernate.format_sql=true
 # 필요할 때만 켜는 걸 추천
 # SQL의 ? 자리에 실제로 어떤 값이 들어가는지 찍어줌
 # logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+
+# MyBatis mapper xml 위치
+mybatis.mapper-locations=classpath:/mapper/**/*.xml
+
+# DTO/VO alias 패키지 
+mybatis.type-aliases-package=com.sejin.platform.domains


### PR DESCRIPTION
## 🧾 PR 한줄 요약
- MyBatis 기반 DB 테스트를 위한 설정 구성과 개발 단계 API 접근을 위한 Security 허용 설정을 추가

---

## 🧩 배경/문제 (Why)
- DB 연결 및 쿼리 실행 여부를 빠르게 확인할 테스트 환경이 필요했고, MyBatis 실행에 필요한 세션 팩토리 구성이 없어 초기 테스트가 막힘
- 또한 기본 Spring Security 설정으로 인해 테스트 API 접근 시 로그인 화면이 떠서 귀찮은 과정이 반복됨 
  - 관련 이슈: #14 

---

## 🎯 목표/범위 (Scope)
- MyBatis 기반 DB 테스트 환경을 안정적으로 구성
- 개발 단계에서는 API 테스트가 막히지 않도록 Security를 전체 허용으로 설정
- 테스트용 컨트롤러/매퍼는 커밋 대상에서 제외

---

## 🛠️ 변경 내용 (What)
- build.gradle : MyBatis 및 JDBC 관련 의존성 추가
- application-common.properties : MyBatis 공통 설정 추가/정리
- MyBatisConfig : SqlSessionFactory/SqlSessionTemplate 명시 등록 및 매퍼 스캔 설정 추가
- SecurityConfig : 개발 단계에서 permitAll 정책으로 전체 요청 허용 설정 추가

---

## 🧠 설계/의사결정 (How & Decision)
[ ] DB 접근 방식은 JPA와 MyBatis 중 고민한 결과, MyBatis를 우선 선택함.
- 이 프로젝트는 엑셀 업로드 이후 데이터 저장뿐 아니라, 조건 필터 조회나 리포트성 조회처럼 다양한 조건 조합 + 다중 테이블 조인이 자주 나올 가능성이 높기 때문
- JPA도 조인 조회가 가능하지만 조회 조건이 복잡해질수록 쿼리 구조가 길어지거나 튜닝 포인트를 잡기 어려워질 수 있어서, 초기부터 SQL을 직접 통제할 수 있는 MyBatis가 더 안정적이라고 판단해서 MyBatis를 선택함
- 동적 조건을 조합해서 조회해야 하는 요구가 많아 XML 기반 동적 SQL로 관리하기 쉬운 MyBatis가 이 프로젝트와 더 잘 맞을 것 같다는 판단을 함.
[ ] 개발 단계 생산성을 위해 Security는 우선 전체 허용으로 두고, 기능 개발 완료 후 인증/인가 정책을 적용하는 방향으로 진행 예정.

---

## ✅ 테스트/검증 (Verification)
- 서버 동작 정상 확인
- 로그인 화면 없이 테스트 API 접근 가능 확인

---

## 🔜 TODO / Follow-up
- 기능 개발 완료 후 Security 정책을 실제 인증/인가 구조로 전환
- Excel 업로드 저장/조회 기능 구현 시 MyBatis XML 매퍼 및 동적 조회 쿼리 적용
