### PR TITLE
[Refactor] 공통 응답 포맷 및 전역 예외 처리 구조 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,19 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	
+	// Jakarta Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
-}
+	tasks.named('test') {
+		useJUnitPlatform()
+	}
+	// 자바 컴파일 시 메서드 파라미터 이름을 유지하도록 설정
+	// 기본적으로 자바는 컴파일하면 파라미터 이름을 제거한다.
+	// 그래서 리플렉션으로 읽으면 arg0, arg1 이런 식으로 나온다.
+	// -parameters 옵션을 주면 실제 선언한 이름(name)을 바이트코드에 보존한다.
+	tasks.withType(JavaCompile) {
+	    options.compilerArgs += ["-parameters"]
+	
+	}

--- a/src/main/java/com/sejin/platform/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sejin/platform/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,166 @@
+package com.sejin.platform.common.exception;
+
+import com.sejin.platform.common.response.ErrorResponse;
+import com.sejin.platform.common.response.ErrorResponse.FieldError;
+
+import jakarta.validation.ConstraintViolationException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * 프로젝트 전체에서 발생하는 예외를 한 곳에서 처리하는 클래스
+ * 컨트롤러에서 예외가 발생하면 여기로 들어와서
+ * 미리 정해둔 ErrorResponse 형식으로 통일해서 내려준다.
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 서버 내부에서 어떤 예외가 발생했는지 로그로 남기기 위한 Logger
+    // 사용자에게는 내부 에러 내용을 그대로 노출하지 않고
+    // 서버 로그로만 원인을 확인하기 위해 사용한다.
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+
+    /*
+     * 1. @Valid 붙은 객체 검증 실패 시 발생
+     * 예: DTO에 @NotBlank, @Size 같은 검증 어노테이션이 붙어있고
+     *     그 조건을 만족하지 못했을 때 발생하는 예외
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+
+        // 어떤 필드가 어떤 이유로 실패했는지 하나씩 꺼내서
+        // FieldError 형태로 변환한다.
+        List<FieldError> errors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fe -> 
+                    // fe.getField() -> 필드명
+                    // fe.getDefaultMessage() -> 검증 실패 메시지
+                    new FieldError(fe.getField(), fe.getDefaultMessage())
+                )
+                .collect(Collectors.toList());
+
+        // 공통 에러 응답 생성
+        ErrorResponse body = ErrorResponse.of(
+                "VALIDATION_ERROR",
+                "입력값이 올바르지 않습니다.",
+                errors
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+
+    /*
+     * 2. 폼 데이터나 쿼리 파라미터 바인딩 실패 시 발생
+     * 예: 숫자여야 하는데 문자가 들어온 경우 등
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> handleBind(BindException e) {
+
+        List<FieldError> errors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fe ->
+                    new FieldError(fe.getField(), fe.getDefaultMessage())
+                )
+                .collect(Collectors.toList());
+
+        ErrorResponse body = ErrorResponse.of(
+                "BIND_ERROR",
+                "요청 파라미터가 올바르지 않습니다.",
+                errors
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+
+    /*
+     * 3. 파일 업로드 용량 초과 시 발생
+     * application 설정에서 최대 용량을 초과하면 이 예외가 터진다.
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUpload(MaxUploadSizeExceededException e) {
+
+        ErrorResponse body = ErrorResponse.of(
+                "FILE_TOO_LARGE",
+                "업로드 파일 용량이 너무 큽니다."
+        );
+
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(body);
+    }
+
+
+    /*
+     * 4. @RequestParam, @PathVariable 등에 붙은 검증 실패
+     * 예: @NotBlank, @Min 같은 검증이 파라미터에 직접 붙은 경우
+     *     @Validated가 클래스에 있어야 동작한다.
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException e){
+
+        // ConstraintViolationException 안에는
+        // 어떤 파라미터가 어떤 규칙을 어겼는지 정보가 들어있다.
+        // 그걸 프론트에 내려줄 수 있도록 변환해준다.
+        List<FieldError> errors = e.getConstraintViolations()
+                .stream()
+                .map(v -> {
+                    // propertyPath 예시:
+                    // "valid.name"
+                    // 여기서 마지막 부분(name)만 잘라내기 위해 아래 코드 사용
+                    String path = v.getPropertyPath().toString();
+
+                    // 점(.)이 있으면 마지막 점 뒤 문자열만 사용
+                    // 예: valid.name -> name
+                    String field = path.contains(".")
+                            ? path.substring(path.lastIndexOf('.') + 1)
+                            : path;
+
+                    return new FieldError(field, v.getMessage());
+                })
+                .collect(Collectors.toList());
+
+        ErrorResponse body = ErrorResponse.of(
+                "VALIDATION_ERROR",
+                "요청 파라미터가 올바르지 않습니다.",
+                errors
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+
+    /*
+     * 5. 그 외 모든 RuntimeException에 대한 안전망
+     * 위에서 잡지 못한 예외가 여기로 들어온다.
+     * 사용자에게는 상세 메시지를 숨기고,
+     * 서버 로그로만 실제 원인을 남긴다.
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntime(RuntimeException e) {
+
+        // 내부 에러 로그 기록
+        log.error("Unhandled RuntimeException", e);
+
+        ErrorResponse body = ErrorResponse.of(
+                "INTERNAL_ERROR",
+                "서버 처리 중 오류가 발생했습니다."
+        );
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
+}

--- a/src/main/java/com/sejin/platform/common/response/ApiResponse.java
+++ b/src/main/java/com/sejin/platform/common/response/ApiResponse.java
@@ -1,0 +1,38 @@
+package com.sejin.platform.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+// 성공 응답을 프로젝트 전체에서 한 형태로 통일시키기 위한 클래스
+// 프론트는 항상 success/code/message/data만 보면 되게 한다.
+
+@JsonInclude(JsonInclude.Include.NON_NULL)	// data가 null이면 응답에서 data를 숨김
+public class ApiResponse<T> {
+	
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+	
+	private ApiResponse(boolean success, String code, String message, T data) {
+		this.success = success;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+	
+	// 데이터가 있는 성공 응답
+	public static <T> ApiResponse<T> ok(T data){
+		return new ApiResponse<>(true, "SUCCESS","요청 성공",data);
+	}
+	
+	// 데이터가 없는 성공 응답(저장/삭제 같은 경우)
+	public static ApiResponse<Void> ok(){
+		return new ApiResponse<>(true, "SUCCESS", "요청 성공", null);
+	}
+	
+	public boolean isSuccess() {return success;}
+	public String getCode() {return code;}
+	public String getmessage() {return message;}
+	public T getData() {return data;}
+
+}

--- a/src/main/java/com/sejin/platform/common/response/ErrorResponse.java
+++ b/src/main/java/com/sejin/platform/common/response/ErrorResponse.java
@@ -1,0 +1,71 @@
+package com.sejin.platform.common.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/*
+ * 프로젝트 전체에서 "실패 응답"을 하나의 형식으로 통일하기 위한 클래스
+ *
+ * 컨트롤러나 서비스에서 예외가 발생하면
+ * GlobalExceptionHandler가 이 객체를 만들어서
+ * JSON 형태로 내려준다.
+ */
+public class ErrorResponse {
+
+    // 항상 실패니까 false로 고정
+    private final boolean success;
+    // 에러 종류 구분용 코드 (예: VALIDATION_ERROR, INTERNAL_ERROR)
+    private final String code;
+    // 사용자에게 보여줄 메시지
+    private final String message;
+    // 필드 단위 에러 목록 (유효성 검증 실패 시 사용)
+    private final List<FieldError> errors;
+    // 에러 발생 시각
+    private final LocalDateTime timestamp;
+
+    /*
+     * 생성자는 외부에서 직접 못 쓰게 private으로 막아둠
+     * 대신 아래 static of() 메서드를 통해서만 생성하도록 설계
+     */
+    private ErrorResponse(String code, String message, List<FieldError> errors) {
+        this.success = false; // 실패 응답이므로 무조건 false
+        this.code = code;
+        this.message = message;
+        this.errors = errors;
+        this.timestamp = LocalDateTime.now(); // 응답 생성 시각 저장
+    }
+
+    // 필드 에러가 없는 일반 실패 응답 생성
+    public static ErrorResponse of(String code, String message) {
+        return new ErrorResponse(code, message, null);
+    }
+
+    // 필드 에러가 포함된 실패 응답 생성
+    public static ErrorResponse of(String code, String message, List<FieldError> errors) {
+        return new ErrorResponse(code, message, errors);
+    }
+
+    // 유효성 검증처럼 필드 단위 에러가 있을 때 사용하는 내부 클래스
+    public static class FieldError {
+
+        // 어떤 필드에서 에러가 났는지
+        private final String field;
+        // 왜 에러가 났는지
+        private final String reason;
+
+        public FieldError(String field, String reason) {
+            this.field = field;
+            this.reason = reason;
+        }
+
+        public String getField() { return field; }
+        public String getReason() { return reason; }
+    }
+
+    // JSON 변환을 위해 필요한 getter들
+    public boolean isSuccess() { return success; }
+    public String getCode() { return code; }
+    public String getMessage() { return message; }
+    public List<FieldError> getErrors() { return errors; }
+    public LocalDateTime getTimestamp() { return timestamp; }
+}


### PR DESCRIPTION
## 🧾 PR 한줄 요약
- 설명: 공통 API 응답 포맷 및 전역 예외 처리 구조를 도입하여 응답 형식을 일관화함

---

## 🧩 배경/문제 (Why)
- 기존에는 API 응답 구조가 통일되어 있지 않아 성공/실패 응답 형식이 일관되지 않았음
- 예외 발생 시 컨트롤러 단에서 개별적으로 처리해야 하는 구조였음
- Validation 예외 메시지도 통일된 포맷으로 관리할 필요가 있었음
- 추후 확장성과 유지보수를 고려해 공통 응답/예외 처리 구조가 필요하다고 판단함    
  - 관련 이슈: #16 

---

## 🎯 목표/범위 (Scope)
[IN]
- ApiResponse 공통 응답 포맷 도입
- ErrorResponse 예외 응답 객체 생성
- GlobalExceptionHandler 전역 예외 처리 구현
- Validation 예외 처리 추가
- build.gradle 설정 추가 (validation 의존성, -parameters 옵션)

[OUT]
- 비즈니스 로직 변경
- 개별 API 리팩토링

---

## 🛠️ 변경 내용 (What)
- ApiResponse 클래스 생성 → 모든 API 응답을 동일한 구조로 반환하도록 정의
- ErrorResponse 클래스 생성 → 예외 발생 시 반환할 에러 포맷 정의
- GlobalExceptionHandler 구현 → 예외를 전역에서 처리하도록 구성
- build.gradle
 spring-boot-starter-validation 의존성 추가
 tasks.withType(JavaCompile) { options.compilerArgs += ["-parameters"] } 옵션 추가

---

## 🧠 설계/의사결정 (How & Decision)
- 선택한 방식: @RestControllerAdvice 기반 전역 예외 처리 적용
- 이유: 컨트롤러 단 중복 예외 처리를 제거하고 일관된 응답 구조를 유지하기 위함
- 응답 구조 통일: 성공/실패 모두 ApiResponse 기반으로 감싸도록 설계
- Validation 처리: MethodArgumentNotValidException을 전역에서 처리하도록 구성
- 컴파일 옵션 추가 이유: Validation 메시지에서 파라미터 이름을 정확히 사용하기 위해 -parameters 옵션 적용

---

## ✅ 테스트/검증 (Verification)
✔ 테스트 시나리오

1. 정상 API 호출 → ApiResponse 성공 구조 반환 확인
2. @NotBlank 등 validation 실패 → 공통 ErrorResponse 구조 반환 확인
3. 존재하지 않는 값 요청 → 지정한 예외 응답 포맷 확인

✔ 테스트를 위해 수행한 작업

1. 테스트용 컨트롤러 생성 (※ 해당 파일은 push하지 않음)
2. build.gradle에 validation 의존성 추가
3. -parameters 옵션 추가 후 컴파일 확인
4. 로컬 서버 실행 후 Postman으로 요청 검증

✔ 체크리스트

- 성공 응답 포맷 통일 확인
- Validation 예외 응답 구조 확인
- 전역 예외 처리 정상 동작 확인
- 로컬 빌드 정상 동작 확인

---

## 🔜 TODO / Follow-up
  - [ ] 비즈니스 예외 체계화